### PR TITLE
Bump flower==0.9.2 (#4263)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'flask-sqlalchemy==2.1',
         'flask-testing==0.6.2',
         'flask-wtf==0.14.2',
-        'flower==0.9.1',
+        'flower==0.9.2',
         'future>=0.16.0, <0.17',
         'python-geohash==0.8.5',
         'humanize==0.5.1',


### PR DESCRIPTION
This PR cherry-picks https://github.com/apache/incubator-superset/pull/4263 which bumps the version of the `flower` package. In the Flower UI @michellethomas and I noticed an UI bug which according to the forums may have been resolved in `0.9.2`.

to: @graceguo-supercat @michellethomas