### PR TITLE
Cherry pick filter fixes

### DIFF
--- a/superset/assets/spec/javascripts/explore/AdhocFilter_spec.js
+++ b/superset/assets/spec/javascripts/explore/AdhocFilter_spec.js
@@ -112,6 +112,26 @@ describe('AdhocFilter', () => {
     });
     // eslint-disable-next-line no-unused-expressions
     expect(adhocFilter3.isValid()).to.be.false;
+
+    const adhocFilter4 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'value',
+      operator: 'in',
+      comparator: [],
+      clause: CLAUSES.WHERE,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(adhocFilter4.isValid()).to.be.false;
+
+    const adhocFilter5 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'value',
+      operator: 'in',
+      comparator: ['val1'],
+      clause: CLAUSES.WHERE,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(adhocFilter5.isValid()).to.be.true;
   });
 
   it('can translate from simple expressions to sql expressions', () => {

--- a/superset/assets/src/explore/AdhocFilter.js
+++ b/superset/assets/src/explore/AdhocFilter.js
@@ -83,7 +83,13 @@ export default class AdhocFilter {
 
   isValid() {
     if (this.expressionType === EXPRESSION_TYPES.SIMPLE) {
-      return !!(this.operator && this.subject && this.comparator && this.clause);
+      return !!(
+        this.operator &&
+        this.subject &&
+        this.comparator &&
+        this.comparator.length > 0 &&
+        this.clause
+      );
     } else if (this.expressionType === EXPRESSION_TYPES.SQL) {
       return !!(this.sqlExpression && this.clause);
     }

--- a/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocFilterEditPopover.jsx
@@ -123,21 +123,24 @@ export default class AdhocFilterEditPopover extends React.Component {
               onHeightChange={this.adjustHeight}
             />
           </Tab>
-          {
-            (!this.props.datasource || this.props.datasource.type !== 'druid') &&
-            <Tab
-              className="adhoc-filter-edit-tab"
-              eventKey={EXPRESSION_TYPES.SQL}
-              title="Custom SQL"
-            >
-              <AdhocFilterEditPopoverSqlTabContent
-                adhocFilter={this.state.adhocFilter}
-                onChange={this.onAdhocFilterChange}
-                options={this.props.options}
-                height={this.state.height}
-              />
-            </Tab>
-          }
+          <Tab
+            className="adhoc-filter-edit-tab"
+            eventKey={EXPRESSION_TYPES.SQL}
+            title="Custom SQL"
+          >
+            {
+              (!this.props.datasource || this.props.datasource.type !== 'druid') ?
+                <AdhocFilterEditPopoverSqlTabContent
+                  adhocFilter={this.state.adhocFilter}
+                  onChange={this.onAdhocFilterChange}
+                  options={this.props.options}
+                  height={this.state.height}
+                /> :
+                <div className="custom-sql-disabled-message">
+                  Custom SQL Filters are not available on druid datasources
+                </div>
+            }
+          </Tab>
         </Tabs>
         <div>
           <Button

--- a/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
+++ b/superset/assets/src/explore/components/AdhocMetricEditPopover.jsx
@@ -225,27 +225,30 @@ export default class AdhocMetricEditPopover extends React.Component {
               <OnPasteSelect {...this.selectProps} {...aggregateSelectProps} />
             </FormGroup>
           </Tab>
-          {
-            this.props.datasourceType !== 'druid' &&
-            <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SQL} title="Custom SQL">
-              <FormGroup>
-                <AceEditor
-                  ref={this.handleAceEditorRef}
-                  mode="sql"
-                  theme="github"
-                  height={(this.state.height - 43) + 'px'}
-                  onChange={this.onSqlExpressionChange}
-                  width="100%"
-                  showGutter={false}
-                  value={adhocMetric.sqlExpression || adhocMetric.translateToSql()}
-                  editorProps={{ $blockScrolling: true }}
-                  enableLiveAutocompletion
-                  className="adhoc-filter-sql-editor"
-                  wrapEnabled
-                />
-              </FormGroup>
-            </Tab>
-          }
+          <Tab className="adhoc-metric-edit-tab" eventKey={EXPRESSION_TYPES.SQL} title="Custom SQL">
+            {
+              this.props.datasourceType !== 'druid' ?
+                <FormGroup>
+                  <AceEditor
+                    ref={this.handleAceEditorRef}
+                    mode="sql"
+                    theme="github"
+                    height={(this.state.height - 43) + 'px'}
+                    onChange={this.onSqlExpressionChange}
+                    width="100%"
+                    showGutter={false}
+                    value={adhocMetric.sqlExpression || adhocMetric.translateToSql()}
+                    editorProps={{ $blockScrolling: true }}
+                    enableLiveAutocompletion
+                    className="adhoc-filter-sql-editor"
+                    wrapEnabled
+                  />
+                </FormGroup> :
+                <div className="custom-sql-disabled-message">
+                  Custom SQL Metrics are not available on druid datasources
+                </div>
+            }
+          </Tab>
         </Tabs>
         <div>
           <Button

--- a/superset/assets/src/explore/main.css
+++ b/superset/assets/src/explore/main.css
@@ -210,3 +210,10 @@
   margin-left: 3px;
   position: static;
 }
+
+.custom-sql-disabled-message {
+  color: gray;
+  font-size: 11px;
+  text-align: center;
+  margin-top: 60px;
+}

--- a/superset/migrations/versions/afb7730f6a9c_remove_empty_filters.py
+++ b/superset/migrations/versions/afb7730f6a9c_remove_empty_filters.py
@@ -1,0 +1,57 @@
+"""remove empty filters
+
+Revision ID: afb7730f6a9c
+Revises: c5756bec8b47
+Create Date: 2018-06-07 09:52:54.535961
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'afb7730f6a9c'
+down_revision = 'c5756bec8b47'
+
+from alembic import op
+import json
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, Text
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = 'slices'
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).all():
+        try:
+            params = json.loads(slc.params)
+
+            for key in ('filters', 'having_filters', 'extra_filters'):
+                value = params.get(key)
+
+                # Remove empty in/not-in filters.
+                if value:
+                    params[key] = [
+                        x for x in value
+                        if not (x['op'] in ('in', 'not in') and not x['val'])
+                    ]
+
+            slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Cherry picking fixes to adhoc filters

empty lists are invalid comparators (#5160) (cherry picked from commit 5b35f75cbffd3ee07d2553e0730e0430bdecc5e2)
[migration] Adding migration to remove empty in/not-in filters (#5161) (cherry picked from commit 1b4406db3f878ac418fc239af03ab76f3b9f20c0)
[Explore][Adhoc Metrics/ Filters] disabled message for custom sql tab in druid (#5162) (cherry picked from commit b53b240710b3b1a9c4965a53bef1c0cd58a1a4e5)

@john-bodley @GabeLoins @timifasubaa @graceguo-supercat 
