### PR TITLE
Fix edge case around NaN values (#4964)

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -217,7 +217,7 @@ class BaseViz(object):
         """Converting metrics to numeric when pandas.read_sql cannot"""
         for col, dtype in df.dtypes.items():
             if dtype.type == np.object_ and col in metrics:
-                df[col] = pd.to_numeric(df[col])
+                df[col] = pd.to_numeric(df[col], errors='coerce')
 
     def query_obj(self):
         """Building a query object"""


### PR DESCRIPTION
(cherry picked from commit e1618ddddba50185375353417dd29826172084aa)

This PR fixes an issue reported in the #superset-goalie channel, `Unable to parse string "NaN" at position 0`. 

to: @graceguo-supercat @kristw @michellethomas @timifasubaa 