### PR TITLE
fix: Pivot table not sorting formatted numeric column properly (#5709)

### DIFF
--- a/superset/assets/src/visualizations/pivot_table.js
+++ b/superset/assets/src/visualizations/pivot_table.js
@@ -62,6 +62,7 @@ function PivotTable(element, props) {
       const tdText = $(this)[0].textContent;
       if (!Number.isNaN(tdText) && tdText !== '') {
         $(this)[0].textContent = d3format(format, tdText);
+        $(this).attr('data-sort', tdText);
       }
     });
   });


### PR DESCRIPTION
* fix: Pivot table not sorting formatted numeric column properly

* refactor(lint): fixed lint error

(cherry picked from commit 4121d57d32e2b786632e9e4cd582a2a3f1e65a53)

to: @graceguo-supercat @kristw @michellethomas @timifasubaa @williaster 