### PR TITLE
Cherrypick csv upload changes (#5268)

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -315,6 +315,10 @@ CSV_TO_HIVE_UPLOAD_S3_BUCKET = None
 # contain all the external tables
 CSV_TO_HIVE_UPLOAD_DIRECTORY = 'EXTERNAL_HIVE_TABLES/'
 
+# The namespace within hive where the tables created from
+# uploading CSVs will be stored.
+UPLOADED_CSV_HIVE_NAMESPACE = None
+
 # A dictionary of items that gets merged into the Jinja context for
 # SQL Lab. The existing context gets updated with this dictionary,
 # meaning values for existing keys get overwritten by the content of this

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -910,6 +910,14 @@ class HiveEngineSpec(PrestoEngineSpec):
                 return next(unicodecsv.reader(f, encoding='utf-8-sig'))
 
         table_name = form.name.data
+        if config.get('UPLOADED_CSV_HIVE_NAMESPACE'):
+            if '.' in table_name:
+                raise Exception(
+                    "You can't specify a namespace. "
+                    'All tables will be uploaded to the `{}` namespace'.format(
+                        config.get('HIVE_NAMESPACE')))
+            table_name = '{}.{}'.format(
+                config.get('UPLOADED_CSV_HIVE_NAMESPACE'), table_name)
         filename = form.csv_file.data.filename
 
         bucket_path = app.config['CSV_TO_HIVE_UPLOAD_S3_BUCKET']

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -910,17 +910,26 @@ class HiveEngineSpec(PrestoEngineSpec):
                 return next(unicodecsv.reader(f, encoding='utf-8-sig'))
 
         table_name = form.name.data
+        schema_name = form.schema.data
+
         if config.get('UPLOADED_CSV_HIVE_NAMESPACE'):
-            if '.' in table_name:
+            if '.' in table_name or schema_name:
                 raise Exception(
                     "You can't specify a namespace. "
                     'All tables will be uploaded to the `{}` namespace'.format(
                         config.get('HIVE_NAMESPACE')))
             table_name = '{}.{}'.format(
                 config.get('UPLOADED_CSV_HIVE_NAMESPACE'), table_name)
-        filename = form.csv_file.data.filename
+        else:
+            if '.' in table_name and schema_name:
+                raise Exception(
+                    "You can't specify a namespace both in the name of the table "
+                    'and in the schema field. Please remove one')
+            if schema_name:
+                table_name = '{}.{}'.format(schema_name, table_name)
 
-        bucket_path = app.config['CSV_TO_HIVE_UPLOAD_S3_BUCKET']
+        filename = form.csv_file.data.filename
+        bucket_path = config['CSV_TO_HIVE_UPLOAD_S3_BUCKET']
 
         if not bucket_path:
             logging.info('No upload bucket specified')

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -950,7 +950,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         s3.upload_file(
             upload_path, bucket_path,
             os.path.join(upload_prefix, table_name, filename))
-        sql = """CREATE EXTERNAL TABLE {table_name} ( {schema_definition} )
+        sql = """CREATE TABLE {table_name} ( {schema_definition} )
             ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS
             TEXTFILE LOCATION '{location}'
             tblproperties ('skip.header.line.count'='1')""".format(**locals())


### PR DESCRIPTION
(cherry picked from commit bd24f854c96390e53bdfb0a3e5c3122928340acf)

This PR cherrypicks changes to the CSV flow that fixes the schema issues people are facing
1. It makes all new CSV uploads internally managed tables and not externally managed tables. 
2. It fixes the issue from before where the schema from the form field was not applied to the schema and caused the table to be uploaded to the default namespace. 
3.  It gives us the option of forcing all csvs into one namespaces should we decide to do so for PII control reasons

@airbnb/superset-fork-maintainers cc @paulbramsen