### PR TITLE
Pin reactable to version 1.0.2 so it works in production mode

### DIFF
--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -114,7 +114,7 @@
     "react-syntax-highlighter": "^5.7.0",
     "react-virtualized": "9.3.0",
     "react-virtualized-select": "2.4.0",
-    "reactable": "^1.1.0",
+    "reactable": "1.0.2",
     "redux": "^3.5.2",
     "redux-localstorage": "^0.4.1",
     "redux-thunk": "^2.1.0",

--- a/superset/assets/yarn.lock
+++ b/superset/assets/yarn.lock
@@ -10092,9 +10092,9 @@ react@^15.6.1, react@^15.6.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-reactable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/reactable/-/reactable-1.1.0.tgz#2f84bb8b3808df8ac64694b539be416438db8498"
+reactable@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reactable/-/reactable-1.0.2.tgz#67a579fee3af68b991b5f04df921a4a40ece0b72"
 
 reactcss@^1.2.0:
   version "1.2.3"


### PR DESCRIPTION
`reactable` `1.1.0` works for development (`npm run dev`) but not production (`npm run build`)
while `1.0.2` works for production not development.

Adding this hotfix to enable our staging and production deployment to move forward.

https://github.com/abdulrahman-khankan/reactable/issues/3

@graceguo-supercat @john-bodley 