### PR TITLE
[bugfix] don't parse save dashboard response (#6349)

### DIFF
--- a/superset/assets/src/dashboard/actions/dashboardState.js
+++ b/superset/assets/src/dashboard/actions/dashboardState.js
@@ -132,6 +132,7 @@ export function saveDashboardRequest(data, id, saveType) {
     SupersetClient.post({
       endpoint: `/superset/${path}/${id}/`,
       postPayload: { data },
+      parseMethod: null,
     })
       .then(response =>
         Promise.all([
@@ -147,7 +148,7 @@ export function saveDashboardRequest(data, id, saveType) {
             addDangerToast(
               `${t(
                 'Sorry, there was an error saving this dashboard: ',
-              )} ${error}}`,
+              )} ${error}`,
             ),
           ),
         ),


### PR DESCRIPTION
* [bugfix] don't parse save dashboard response

* [dashboard] remove bracket in error message

(cherry picked from commit 62dcce890c36168c91b80eee301dc0ef4d47a8ef)