### PR TITLE
Fixing issue with filter_box time grain control

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -915,7 +915,9 @@ export const controls = {
     'The options here are defined on a per database ' +
     'engine basis in the Superset source code.'),
     mapStateToProps: state => ({
-      choices: (state.datasource) ? state.datasource.time_grain_sqla : null,
+      choices: (state.datasource) ?
+        state.datasource.time_grain_sqla || state.datasource.timeGrainSqla :
+        null,
     }),
   },
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
There's an issue in 0.33 where the dropdown for the time grain sqla control doesn't show any options. This is fixed in a PR in master, but it comes with a number of other changes we don't want to commit. This is a temporary fix just for 0.33.

### TEST PLAN
Create a filter box
Check the time grain sql box
Verify there are options in the dropdown and also options in the main time grain dropdown

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@graceguo-supercat @john-bodley @etr2460