### PR TITLE
Updating superset-ui/legacy-preset-chart-nvd3 to 0.10.35

### DIFF
--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -2911,9 +2911,9 @@
       }
     },
     "@superset-ui/legacy-preset-chart-nvd3": {
-      "version": "0.10.32",
-      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.10.32.tgz",
-      "integrity": "sha512-2tc2ZL+PkMxqnnRbB3njVBbXvul8Q+C/NlylXj2jhdFbQxq+DaNj73KSCvIl2jAuaYyZNxbir0pT9ugibQQ1Yw==",
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/@superset-ui/legacy-preset-chart-nvd3/-/legacy-preset-chart-nvd3-0.10.35.tgz",
+      "integrity": "sha512-9R+nykI93m5h8GsOA+5We9DcZ9U3e+KlAn2Lpc+S4hyvSQTSluKx3+cGBxHzr6idFuyU6wC2InAVWDEGQhr0Cw==",
       "requires": {
         "@data-ui/xy-chart": "^0.0.78",
         "d3": "^3.5.17",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -75,7 +75,7 @@
     "@superset-ui/legacy-plugin-chart-word-cloud": "^0.10.11",
     "@superset-ui/legacy-plugin-chart-world-map": "^0.10.11",
     "@superset-ui/legacy-preset-chart-big-number": "^0.10.11",
-    "@superset-ui/legacy-preset-chart-nvd3": "^0.10.32",
+    "@superset-ui/legacy-preset-chart-nvd3": "^0.10.35",
     "@superset-ui/number-format": "^0.11.3",
     "@superset-ui/time-format": "^0.11.3",
     "@superset-ui/translation": "^0.11.0",


### PR DESCRIPTION
(cherry picked from commit b66f73b9195cb6f1e4792a60b490a09de156bed2)

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Updating superset UI to fix bug with area chart tooltip. 

### TEST PLAN
test an area chart with expanded stacked style

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@etr2460 @graceguo-supercat 