### PR TITLE
disable event listeners for tagged_objects update

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -48,7 +48,6 @@ from superset import app, db, db_engine_specs, security_manager
 from superset.connectors.connector_registry import ConnectorRegistry
 from superset.legacy import update_time_range
 from superset.models.helpers import AuditMixinNullable, ImportMixin
-from superset.models.tags import ChartUpdater, DashboardUpdater, FavStarUpdater
 from superset.models.user_attributes import UserAttribute
 from superset.utils import (
     cache as cache_util,
@@ -1275,11 +1274,11 @@ class DatasourceAccessRequest(Model, AuditMixinNullable):
 
 
 # events for updating tags
-sqla.event.listen(Slice, 'after_insert', ChartUpdater.after_insert)
-sqla.event.listen(Slice, 'after_update', ChartUpdater.after_update)
-sqla.event.listen(Slice, 'after_delete', ChartUpdater.after_delete)
-sqla.event.listen(Dashboard, 'after_insert', DashboardUpdater.after_insert)
-sqla.event.listen(Dashboard, 'after_update', DashboardUpdater.after_update)
-sqla.event.listen(Dashboard, 'after_delete', DashboardUpdater.after_delete)
-sqla.event.listen(FavStar, 'after_insert', FavStarUpdater.after_insert)
-sqla.event.listen(FavStar, 'after_delete', FavStarUpdater.after_delete)
+# sqla.event.listen(Slice, 'after_insert', ChartUpdater.after_insert)
+# sqla.event.listen(Slice, 'after_update', ChartUpdater.after_update)
+# sqla.event.listen(Slice, 'after_delete', ChartUpdater.after_delete)
+# sqla.event.listen(Dashboard, 'after_insert', DashboardUpdater.after_insert)
+# sqla.event.listen(Dashboard, 'after_update', DashboardUpdater.after_update)
+# sqla.event.listen(Dashboard, 'after_delete', DashboardUpdater.after_delete)
+# sqla.event.listen(FavStar, 'after_insert', FavStarUpdater.after_insert)
+# sqla.event.listen(FavStar, 'after_delete', FavStarUpdater.after_delete)


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Issue is reported in open source [#7807](https://github.com/apache/incubator-superset/issues/7807). The solution will require db migration (and more). We only had this feature running <3 months, but the performance became so bad that many of our large dashboards currently can not be save_as any more. So we really need a quick solution.

We will disable all event listeners for tagged_objects table update. And later, if we decided to enable `tagged system` feature, we probably should empty tags and tagged_object table, to have a clean start point.


### TEST PLAN
save_as large dashboard like: [this](https://superset.d.musta.ch/superset/dashboard/4739/) and [this](https://superset.d.musta.ch/superset/dashboard/5429/)


### REVIEWERS
@michellethomas @etr2460 @john-bodley 
