### PR TITLE
Add dashboard loading indicator

### DIFF
--- a/superset/assets/src/dashboard/components/Header.jsx
+++ b/superset/assets/src/dashboard/components/Header.jsx
@@ -25,6 +25,7 @@ import HeaderActionsDropdown from './HeaderActionsDropdown';
 import EditableTitle from '../../components/EditableTitle';
 import Button from '../../components/Button';
 import FaveStar from '../../components/FaveStar';
+import Loading from '../../components/Loading';
 import UndoRedoKeylisteners from './UndoRedoKeylisteners';
 
 import { chartPropShape } from '../util/propShapes';
@@ -266,6 +267,7 @@ class Header extends React.PureComponent {
               isStarred={this.props.isStarred}
             />
           </span>
+          <span className="dashboard-loading">{isLoading && <Loading />}</span>
         </div>
 
         <div className="button-container">

--- a/superset/assets/src/dashboard/stylesheets/dashboard.less
+++ b/superset/assets/src/dashboard/stylesheets/dashboard.less
@@ -207,6 +207,11 @@ body {
     position: relative;
     margin-left: 8px;
   }
+
+  .dashboard-loading {
+    position: relative;
+    padding: 0 30px;
+  }
 }
 
 .ace_gutter {


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Adds a top-level dashboard loading indicator. 

Today, we show loading indicators overlaying each chart on the dashboard, but we don't show a top-level indicator for the full dashboard. This is problematic because the loading indicators are sometimes easy to miss (e.g., loading is happening in other dashboard sub-tabs, or loading indicator on chart has low-contrast).

**Additional Background**:
I use Superset heavily (on the Airbnb Human Team), and have been working with non-engs that use these dashboards frequently. I keep getting feedback on different perf-related issues, and I feel like it's eroding their trust in the data. 

I'm throwing up this "central" loading indicator to make it clearer that no more "loading" is taking place on the dashboard, so they can hopefully have more confidence that the numbers are "ready". (Before this, they would toggle dashboard filters, and the chart-by-chart loading indicators would cause them to feel unsure whether the data is ready to be interpreted.)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Dashboard while loading | Dashboard after loading finishes
--- | ---
<img width="1514" alt="Screen Shot 2019-07-18 at 11 17 30 AM" src="https://user-images.githubusercontent.com/490393/61482051-97c00d80-a94e-11e9-84d0-90e176977d1f.png"> | <img width="1506" alt="Screen Shot 2019-07-18 at 11 17 49 AM" src="https://user-images.githubusercontent.com/490393/61482062-9b539480-a94e-11e9-9a2e-98992bed1518.png">


### TEST PLAN
Followed CONTRIBUTING.md docs, set up local Superset instance and confirmed changes locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@williaster @john-bodley @michellethomas (unsure who to tag)